### PR TITLE
Use math.MinInt64 and math.MaxInt64 as lower and upper bounds

### DIFF
--- a/micro.go
+++ b/micro.go
@@ -221,3 +221,14 @@ func Add(a Micro, b Micro) (Micro, error) {
 	}
 	return result, nil
 }
+
+func Mul(amount Micro, multiplier int64) (Micro, error) {
+	var mult = Micro(multiplier)
+	result := amount * mult
+
+	if mult != 0 && result/mult != amount {
+		return 0, ErrOverflow
+	}
+
+	return result, nil
+}

--- a/micro.go
+++ b/micro.go
@@ -83,10 +83,6 @@ func ToFloatString(amount Micro) (string, error) {
 
 func FromFloat64(amount float64) (Micro, error) {
 	fPrecision := float64(precision)
-	if amount == -9223372036854.775808 {
-		fmt.Println(amount)
-		fmt.Println(float64(MaxMicro) / fPrecision)
-	}
 	if amount > float64(MaxMicro)/fPrecision || amount < float64(MinMicro)/fPrecision {
 		return 0, ErrOverflow
 	}

--- a/micro.go
+++ b/micro.go
@@ -10,14 +10,14 @@ import (
 )
 
 const (
-	precisionExp         = int64(6)
-	precision            = Micro(1000000)
-	largestAmount        = math.MaxInt64
-	smallestAmount       = math.MinInt64
-	Zero                 = Micro(0)
-	MicroDollar    Micro = 1
-	Cent                 = 10000 * MicroDollar
-	Dollar               = 100 * Cent
+	precisionExp       = int64(6)
+	precision          = Micro(1000000)
+	MaxMicro           = math.MaxInt64
+	MinMicro           = math.MinInt64
+	Zero               = Micro(0)
+	MicroDollar  Micro = 1
+	Cent               = 10000 * MicroDollar
+	Dollar             = 100 * Cent
 )
 
 var ErrInvalidInput = errors.New("Cannot convert string to money.Micro.")
@@ -51,10 +51,6 @@ func FromFloatString(amount string) (Micro, error) {
 }
 
 func ToFloatString(amount Micro) (string, error) {
-	if err := checkNumberBounds(int64(amount)); err != nil {
-		return "", err
-	}
-
 	decimal := amount / precision
 	fraction := amount % precision
 
@@ -89,9 +85,9 @@ func FromFloat64(amount float64) (Micro, error) {
 	fPrecision := float64(precision)
 	if amount == -9223372036854.775808 {
 		fmt.Println(amount)
-		fmt.Println(float64(largestAmount) / fPrecision)
+		fmt.Println(float64(MaxMicro) / fPrecision)
 	}
-	if amount > float64(largestAmount)/fPrecision || amount < float64(smallestAmount)/fPrecision {
+	if amount > float64(MaxMicro)/fPrecision || amount < float64(MinMicro)/fPrecision {
 		return 0, ErrOverflow
 	}
 
@@ -102,9 +98,6 @@ func FromFloat64(amount float64) (Micro, error) {
 }
 
 func ToFloat64(amount Micro) (float64, error) {
-	if err := checkNumberBounds(int64(amount)); err != nil {
-		return 0, err
-	}
 	result := float64(amount) / float64(precision)
 
 	return result, nil
@@ -115,14 +108,6 @@ func DivideAndRound(a Micro, b int64) Micro {
 		return (a - (Micro(b) / 2)) / Micro(b)
 	}
 	return (a + (Micro(b) / 2)) / Micro(b)
-}
-
-func checkNumberBounds(amount int64) error {
-	if amount < smallestAmount || amount > largestAmount {
-		return ErrOverflow
-	}
-
-	return nil
 }
 
 func parseFloatString(amount string) (Micro, error) {
@@ -221,9 +206,6 @@ func parseFloatString(amount string) (Micro, error) {
 	}
 
 	resultSigned := int64(result) * sign
-	if err := checkNumberBounds(resultSigned); err != nil {
-		return 0, err
-	}
 
 	return Micro(resultSigned), nil
 }

--- a/micro.go
+++ b/micro.go
@@ -20,7 +20,7 @@ const (
 	Dollar             = 100 * Cent
 )
 
-var ErrInvalidInput = errors.New("Cannot convert string to money.Micro.")
+var ErrInvalidInput = errors.New("money: cannot convert string to money.Micro")
 var ErrOverflow = errors.New("money: overflow occurred")
 
 type Micro int64
@@ -219,16 +219,5 @@ func Add(a Micro, b Micro) (Micro, error) {
 	if a > 0 && b > 0 && result <= 0 {
 		return 0, ErrOverflow
 	}
-	return result, nil
-}
-
-func Mul(amount Micro, multiplier int64) (Micro, error) {
-	var mult = Micro(multiplier)
-	result := amount * mult
-
-	if mult != 0 && result/mult != amount {
-		return 0, ErrOverflow
-	}
-
 	return result, nil
 }

--- a/micro_test.go
+++ b/micro_test.go
@@ -1,7 +1,6 @@
 package money
 
 import (
-	"database/sql/driver"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -33,39 +32,40 @@ var parseFloatStringTests = []parseFloatStringTest{
 	{"000001.1", 110 * Cent, nil},
 	{"0.", Micro(0), nil},
 	{".1", 10 * Cent, nil},
-	{"0.1e10", 1000000000 * Dollar, nil},
-	{"0.1E10", 1000000000 * Dollar, nil},
-	{".1e10", 1000000000 * Dollar, nil},
-	{"1e10", Micro(0), ErrOverBounds},
-	{"100000000000000000000000", Micro(0), ErrOverBounds},
-	{"1e-100", 0, nil},
+	{"0.1e10", 0, ErrInvalidInput},
+	{"0.1E10", 0, ErrInvalidInput},
+	{".1e10", 0, ErrInvalidInput},
+	{"1e10", 0, ErrInvalidInput},
+	{"100000000000000000000000", 0, ErrOverflow},
+	{"1e-100", 0, ErrInvalidInput},
 	{"123456700", 123456700 * Dollar, nil},
 	{"-1", -1 * Dollar, nil},
 	{"-0.1", -10 * Cent, nil},
 	{"-0", 0, nil},
-	{"1e-20", 0, nil},
-	{"625e-3", 625000, nil},
+	{"1e-20", 0, ErrInvalidInput},
+	{"625e-3", 0, ErrInvalidInput},
+	{"9223372036854.775807", 9223372036854775807, nil},
+	{"-9223372036854.775808", -9223372036854775808, nil},
 
 	// NaNs
-	{"nan", 0, ErrOverBounds},
-	{"NaN", 0, ErrOverBounds},
-	{"NAN", 0, ErrOverBounds},
+	{"nan", 0, ErrInvalidInput},
+	{"NaN", 0, ErrInvalidInput},
+	{"NAN", 0, ErrInvalidInput},
 
 	// Infs
-	{"inf", 0, ErrOverBounds},
-	{"-Inf", 0, ErrOverBounds},
-	{"+INF", 0, ErrOverBounds},
-	{"-Infinity", 0, ErrOverBounds},
-	{"+INFINITY", 0, ErrOverBounds},
-	{"Infinity", 0, ErrOverBounds},
+	{"inf", 0, ErrInvalidInput},
+	{"-Inf", 0, ErrInvalidInput},
+	{"+INF", 0, ErrInvalidInput},
+	{"-Infinity", 0, ErrInvalidInput},
+	{"+INFINITY", 0, ErrInvalidInput},
+	{"Infinity", 0, ErrInvalidInput},
 
 	// largest money
 	{"9000000000.000000", 9000000000000000, nil},
 	{"-9000000000.000000", -9000000000000000, nil},
 	// too large
-	{"9000000000.000001", 0, ErrOverBounds},
-	{"-9000000000.000001", 0, ErrOverBounds},
-	{"9000000000e1", 0, ErrOverBounds},
+	{"9223372036854.775808", 0, ErrOverflow},
+	{"-9223372036854.775809", 0, ErrOverflow},
 
 	// parse errors
 	{"1e", 0, ErrInvalidInput},
@@ -95,28 +95,12 @@ var parseFloatStringTests = []parseFloatStringTest{
 	{"1.00000000000000011102230246251565404236316680908203125", Dollar, nil},
 	{"-1.00000000000000011102230246251565404236316680908203125", -1 * Dollar, nil},
 	// max int64 + 1 for overflow
-	{"9223372036854.775808", 0, ErrOverBounds},
-	{"-9223372036854.775808", 0, ErrOverBounds},
+	{"9223372036854.775808", 0, ErrOverflow},
+	{"-9223372036854.775809", 0, ErrOverflow},
 	// a number that overflows but seemingly stops overflowing on the last iteration
-	{"92233720368547758087", 0, ErrOverBounds},
+	{"92233720368547758087", 0, ErrOverflow},
 	// a huge number
-	{"100000000000000011102230246251565404236316680908203125" + strings.Repeat("0", 10000) + "1", 0, ErrOverBounds},
-
-	// try overflown number with exp that produces valid number
-	{"9.223372036854775808123e-2", 92234, nil},
-	{"9223372036854775808123e-20", 92233720, nil},
-	// mantissa overflows but exp makes it valid
-	{"9223372036854775808.223372036854775808e-10", 922337203685478, nil},
-
-	{"1e-9223372036854775808", 0, nil},
-	// exp is too big and we fall into infinity territory
-	{"1e+9223372036854775807", 0, ErrOverBounds},
-
-	// try to overflow exp
-	{"1e-9223372036854775809", 0, nil},
-	{"1e+9223372036854775808", 0, ErrOverBounds},
-	{"1e-18446744073709551616", 0, nil},
-	{"1e+18446744073709551616", 0, ErrOverBounds},
+	{"100000000000000011102230246251565404236316680908203125" + strings.Repeat("0", 10000) + "1", 0, ErrOverflow},
 }
 
 var addTests = []addTest{
@@ -143,14 +127,14 @@ type MoneyTestSuite struct {
 
 func (suite *MoneyTestSuite) TestMarshalJSON() {
 	var mNil *Micro
-	v, err := json.Marshal(mNil)
+	result, err := json.Marshal(mNil)
 	suite.Nil(err)
-	suite.Equal([]byte("null"), v)
+	suite.Equal("null", string(result))
 
 	m := Micro(0)
-	result, err := (&m).MarshalJSON()
+	result, err = (&m).MarshalJSON()
 	suite.Nil(err)
-	suite.Equal([]byte{0x30}, result)
+	suite.Equal("0", string(result))
 
 	m = 8 * Dollar
 	result, err = (&m).MarshalJSON()
@@ -176,20 +160,6 @@ func (suite *MoneyTestSuite) TestMarshalJSON() {
 	result, err = (&m).MarshalJSON()
 	suite.Nil(err)
 	suite.Equal("-8.01", string(result))
-}
-
-func (suite *MoneyTestSuite) TestInvalidMarshalJSON() {
-	m := Micro(9000000000000001)
-	result, err := (&m).MarshalJSON()
-	suite.Equal(ErrOverBounds, err)
-	suite.Nil(result)
-	suite.Equal(Micro(9000000000000001), m)
-
-	m = Micro(-9000000000000001)
-	result, err = (&m).MarshalJSON()
-	suite.Equal(ErrOverBounds, err)
-	suite.Nil(result)
-	suite.Equal(Micro(-9000000000000001), m)
 }
 
 func (suite *MoneyTestSuite) TestUnmarshalJSON() {
@@ -241,93 +211,14 @@ func (suite *MoneyTestSuite) TestUnmarshalJSON() {
 
 func (suite *MoneyTestSuite) TestInvalidUnmarshalJSON() {
 	m := Micro(0)
-	err := (&m).UnmarshalJSON([]byte("9000000000.01"))
-	suite.Equal(ErrOverBounds, err)
+	err := (&m).UnmarshalJSON([]byte("9223372036854.775808"))
+	suite.Equal(ErrOverflow, err)
 	suite.Equal(Micro(0), m)
 
 	m = Micro(10)
-	err = (&m).UnmarshalJSON([]byte("-9000000000.01"))
-	suite.Equal(ErrOverBounds, err)
+	err = (&m).UnmarshalJSON([]byte("-9223372036854.775809"))
+	suite.Equal(ErrOverflow, err)
 	suite.Equal(Micro(10), m)
-}
-
-func (suite *MoneyTestSuite) TestScan() {
-	var mNil *Micro
-	err := mNil.Scan(nil)
-	suite.Nil(err)
-	suite.Equal((*Micro)(nil), mNil)
-
-	m := Micro(0)
-	err = (&m).Scan([]uint8{48, 46, 48, 56, 48, 48, 48, 48})
-	suite.Nil(err)
-	suite.Equal(Micro(80000), m)
-
-	err = (&m).Scan([]uint8{48, 46, 51, 53, 48, 48, 48, 48})
-	suite.Nil(err)
-	suite.Equal(Micro(350000), m)
-
-	err = (&m).Scan([]uint8{49, 46, 50, 53, 48, 48, 48, 48})
-	suite.Nil(err)
-	suite.Equal(Micro(1250000), m)
-
-	err = (&m).Scan([]uint8{49, 48, 48, 48, 46, 48, 48, 48, 48, 48, 48})
-	suite.Nil(err)
-	suite.Equal(Micro(1000000000), m)
-
-	err = (&m).Scan([]uint8{45, 49, 46, 48, 48, 48, 48, 48, 48})
-	suite.Nil(err)
-	suite.Equal(Micro(-1000000), m)
-}
-
-func (suite *MoneyTestSuite) TestInvalidScan() {
-	m := Micro(100)
-	// 9000000000.000001
-	err := (&m).Scan([]uint8{57, 48, 48, 48, 48, 48, 48, 48, 48, 48, 46, 48, 48, 48, 48, 48, 49})
-	suite.Equal(ErrOverBounds, err)
-	suite.Equal(Micro(100), m)
-
-	// -9000000000.000001
-	err = (&m).Scan([]uint8{45, 57, 48, 48, 48, 48, 48, 48, 48, 48, 48, 46, 48, 48, 48, 48, 48, 49})
-	suite.Equal(ErrOverBounds, err)
-	suite.Equal(Micro(100), m)
-}
-
-func (suite *MoneyTestSuite) TestValue() {
-	m := new(Micro)
-	*m = 12 * Cent
-	val, err := m.Value()
-	suite.Nil(err)
-	suite.Equal("0.12", val)
-
-	*m = 125 * Cent
-	val, err = m.Value()
-	suite.Nil(err)
-	suite.Equal("1.25", val)
-
-	*m = 0 * Cent
-	val, err = m.Value()
-	suite.Nil(err)
-	suite.Equal("0", val)
-
-	mv := 12 * Cent
-	val, err = mv.Value()
-	suite.Nil(err)
-	suite.Equal("0.12", val)
-
-	_ = driver.Valuer(mv)
-}
-
-func (suite *MoneyTestSuite) TestInvalidValue() {
-	m := new(Micro)
-	*m = 9000000000000001
-	val, err := m.Value()
-	suite.Equal(ErrOverBounds, err)
-	suite.Equal(nil, val)
-
-	*m = -9000000000000001
-	val, err = m.Value()
-	suite.Equal(ErrOverBounds, err)
-	suite.Equal(nil, val)
 }
 
 func (suite *MoneyTestSuite) TestValidFromFloatString() {
@@ -374,59 +265,41 @@ func (suite *MoneyTestSuite) TestInvalidFromFloatString() {
 	suite.Equal(Micro(0), result)
 
 	result, err = FromFloatString("13849502840392485906123.764538")
-	suite.Equal(ErrOverBounds, err)
+	suite.Equal(ErrOverflow, err)
 	suite.Equal(Micro(0), result)
 
-	result, err = FromFloatString("-9000000000.000001")
-	suite.Equal(ErrOverBounds, err)
+	result, err = FromFloatString("-9223372036854.775809")
+	suite.Equal(ErrOverflow, err)
 	suite.Equal(Micro(0), result)
 
-	result, err = FromFloatString("9000000000.000001")
-	suite.Equal(ErrOverBounds, err)
+	result, err = FromFloatString("9223372036854.775808")
+	suite.Equal(ErrOverflow, err)
 	suite.Equal(Micro(0), result)
-}
-
-func (suite *MoneyTestSuite) TestValidFromFloatStringWithExp() {
-	result, err := FromFloatString("123.764538e6")
-	suite.Nil(err)
-	suite.Equal(Micro(123764538000000), result)
-
-	result, err = FromFloatString("123.764538E6")
-	suite.Nil(err)
-	suite.Equal(Micro(123764538000000), result)
-
-	result, err = FromFloatString("123.764538e+6")
-	suite.Nil(err)
-	suite.Equal(Micro(123764538000000), result)
-
-	result, err = FromFloatString("3.7134234545e9")
-	suite.Nil(err)
-	suite.Equal(Micro(3713423454500000), result)
-
-	result, err = FromFloatString("0.725344545454654645e10")
-	suite.Nil(err)
-	suite.Equal(Micro(7253445454546546), result)
-
-	result, err = FromFloatString("123.764538e-6")
-	suite.Nil(err)
-	suite.Equal(Micro(124), result)
-
-	result, err = FromFloatString("12345.7e-10")
-	suite.Nil(err)
-	suite.Equal(Micro(1), result)
 }
 
 func (suite *MoneyTestSuite) TestInvalidFromFloatStringWithExp() {
-	result, err := FromFloatString("3.7e10")
-	suite.Equal(ErrOverBounds, err)
+	result, err := FromFloatString("123.764538e6")
+	suite.Equal(ErrInvalidInput, err)
+	suite.Equal(Micro(0), result)
+
+	result, err = FromFloatString("123.764538E6")
+	suite.Equal(ErrInvalidInput, err)
+	suite.Equal(Micro(0), result)
+
+	result, err = FromFloatString("123.764538e+6")
+	suite.Equal(ErrInvalidInput, err)
+	suite.Equal(Micro(0), result)
+
+	result, err = FromFloatString("3.7e10")
+	suite.Equal(ErrInvalidInput, err)
 	suite.Equal(Micro(0), result)
 
 	result, err = FromFloatString("-3.7e10")
-	suite.Equal(ErrOverBounds, err)
+	suite.Equal(ErrInvalidInput, err)
 	suite.Equal(Micro(0), result)
 
 	result, err = FromFloatString("3.7134234545e10")
-	suite.Equal(ErrOverBounds, err)
+	suite.Equal(ErrInvalidInput, err)
 	suite.Equal(Micro(0), result)
 }
 
@@ -464,101 +337,81 @@ func (suite *MoneyTestSuite) TestValidToFloatString() {
 	suite.Equal("-123.764538", result)
 }
 
-func (suite *MoneyTestSuite) TestInvalidToFloatString() {
-	result, err := ToFloatString(Micro(9000000000000001))
-	suite.Equal(ErrOverBounds, err)
-	suite.Equal("", result)
-
-	result, err = ToFloatString(Micro(-9000000000000001))
-	suite.Equal(ErrOverBounds, err)
-	suite.Equal("", result)
-}
-
-func (suite *MoneyTestSuite) TestToFloat64Dollar() {
-	result, err := ToFloat64Dollar(123764538)
+func (suite *MoneyTestSuite) TestToFloat64() {
+	result, err := ToFloat64(123764538)
 	suite.Nil(err)
 	suite.Equal(123.764538, result)
 
-	result, err = ToFloat64Dollar(123)
+	result, err = ToFloat64(123)
 	suite.Nil(err)
 	suite.Equal(0.000123, result)
 
-	result, err = ToFloat64Dollar(400)
+	result, err = ToFloat64(400)
 	suite.Nil(err)
 	suite.Equal(0.0004, result)
 
-	result, err = ToFloat64Dollar(0)
+	result, err = ToFloat64(0)
 	suite.Nil(err)
 	suite.Equal(0.0, result)
 
-	result, err = ToFloat64Dollar(124311)
+	result, err = ToFloat64(124311)
 	suite.Nil(err)
 	suite.Equal(0.124311, result)
 
-	result, err = ToFloat64Dollar(1204311)
+	result, err = ToFloat64(1204311)
 	suite.Nil(err)
 	suite.Equal(1.204311, result)
 
-	result, err = ToFloat64Dollar(1204311)
+	result, err = ToFloat64(1204311)
 	suite.Nil(err)
 	suite.Equal(1.204311, result)
 
-	result, err = ToFloat64Dollar(10204311)
+	result, err = ToFloat64(10204311)
 	suite.Nil(err)
 	suite.Equal(10.204311, result)
 
-	result, err = ToFloat64Dollar(0)
+	result, err = ToFloat64(0)
 	suite.Nil(err)
 	suite.Equal(float64(0), result)
 
-	result, err = ToFloat64Dollar(9000000000000000)
+	result, err = ToFloat64(9000000000000000)
 	suite.Nil(err)
 	suite.Equal(9000000000.000000, result)
 }
 
-func (suite *MoneyTestSuite) TestInvalidToFloat64Dollar() {
-	result, err := ToFloat64Dollar(-9000000000000001)
-	suite.Equal(ErrOverBounds, err)
-	suite.Equal(float64(0), result)
-
-	result, err = ToFloat64Dollar(9000000000000001)
-	suite.Equal(ErrOverBounds, err)
-	suite.Equal(float64(0), result)
-}
-
-func (suite *MoneyTestSuite) TestValidFromFloat64Dollar() {
-	result, err := FromFloat64Dollar(123.764538)
+func (suite *MoneyTestSuite) TestValidFromFloat64() {
+	result, err := FromFloat64(123.764538)
 	suite.Nil(err)
 	suite.Equal(Micro(123764538), result)
 
-	result, err = FromFloat64Dollar(123.52348976)
+	result, err = FromFloat64(123.52348976)
 	suite.Nil(err)
 	suite.Equal(Micro(123523489), result)
 
-	result, err = FromFloat64Dollar(123.523489)
+	result, err = FromFloat64(123.523489)
 	suite.Nil(err)
 	suite.Equal(Micro(123523489), result)
 
-	result, err = FromFloat64Dollar(123)
+	result, err = FromFloat64(123)
 	suite.Nil(err)
 	suite.Equal(Micro(123000000), result)
 
-	result, err = FromFloat64Dollar(12.3)
+	result, err = FromFloat64(12.3)
 	suite.Nil(err)
 	suite.Equal(Micro(12300000), result)
 }
 
-func (suite *MoneyTestSuite) TestInvalidFromFloat64Dollar() {
-	result, err := FromFloat64Dollar(13849502840392485906123.764538)
-	suite.Equal(ErrOverBounds, err)
+func (suite *MoneyTestSuite) TestInvalidFromFloat64() {
+	result, err := FromFloat64(13849502840392485906123.764538)
+	suite.Equal(ErrOverflow, err)
 	suite.Equal(Micro(0), result)
 
-	result, err = FromFloat64Dollar(-9000000000.000001)
-	suite.Equal(ErrOverBounds, err)
+	result, err = FromFloat64(-9223372036854.776808)
+	suite.Equal(ErrOverflow, err)
 	suite.Equal(Micro(0), result)
 
-	result, err = FromFloat64Dollar(9000000000.000001)
-	suite.Equal(ErrOverBounds, err)
+	result, err = FromFloat64(9223372036854.776807)
+	suite.Equal(ErrOverflow, err)
 	suite.Equal(Micro(0), result)
 }
 
@@ -608,6 +461,14 @@ func (suite *MoneyTestSuite) TestParseFloatString() {
 	}
 }
 
+func (suite *MoneyTestSuite) TestAdd() {
+	for _, test := range addTests {
+		result, err := Add(test.input1, test.input2)
+		suite.Equal(test.err, err, fmt.Sprintf("Inputs: %d, %d", test.input1, test.input2))
+		suite.Equal(test.expected, result, fmt.Sprintf("Inputs: %d, %d", test.input1, test.input2))
+	}
+}
+
 func BenchmarkFromFloatString(b *testing.B) {
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
@@ -625,23 +486,5 @@ func BenchmarkFromFloatStringWithExp(b *testing.B) {
 		if err != nil {
 			b.Error(errors.New("Unsuccessful call."))
 		}
-	}
-}
-
-func BenchmarkParseFloatString(b *testing.B) {
-	b.StartTimer()
-	for i := 0; i < b.N; i++ {
-		_, err := parseFloatString("123.52348976")
-		if err != nil {
-			b.Error(errors.New("Unsuccessful call."))
-		}
-	}
-}
-
-func (suite *MoneyTestSuite) TestAdd() {
-	for _, test := range addTests {
-		result, err := Add(test.input1, test.input2)
-		suite.Equal(test.err, err, fmt.Sprintf("Inputs: %d, %d", test.input1, test.input2))
-		suite.Equal(test.expected, result, fmt.Sprintf("Inputs: %d, %d", test.input1, test.input2))
 	}
 }

--- a/micro_test.go
+++ b/micro_test.go
@@ -521,7 +521,7 @@ func BenchmarkFromFloatStringWithExp(b *testing.B) {
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
 		_, err := FromFloatString("123.52348976e-2")
-		if err != nil {
+		if err == nil {
 			b.Error(errors.New("Unsuccessful call."))
 		}
 	}


### PR DESCRIPTION
We wanted to get rid of arbitrary largestAmount and smallestAmount and use the whole int64 space available to use.